### PR TITLE
Removing accidental (?) write to global state

### DIFF
--- a/App/Lennox-iComfort-connect.groovy
+++ b/App/Lennox-iComfort-connect.groovy
@@ -52,8 +52,8 @@ def prefLogIn() {
 }
 
 def prefListDevice() {
-	LoginResult = loginCheck()
-	if (LoginResult) 
+	def loginResult = loginCheck()
+	if (loginResult) 
 	{
 		def thermostatList = getThermostatList()
 		if (thermostatList) {


### PR DESCRIPTION
I'm not sure this is even supported, and I'm guessing this was by accident.